### PR TITLE
initial Red Carpet Bingo added!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "applaudit",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/ssr": "^0.8.0",
@@ -268,6 +270,45 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.8.0",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -48,6 +48,18 @@ export default function LoginPage() {
             </p>
 
             <EmailForm onSubmit={handleSubmit} isLoading={isLoading} />
+
+            {/* Prototype only: skip email and go to verify — remove before production */}
+            <button
+              type="button"
+              onClick={() => {
+                signInWithEmail("prototype@example.com");
+                router.push("/verify");
+              }}
+              className="mt-4 w-full text-sm text-muted-foreground hover:text-foreground transition-colors underline"
+            >
+              Pretend I have one
+            </button>
           </Card>
         </main>
       </PageTransition>

--- a/src/app/(onboarding)/ballot/page.tsx
+++ b/src/app/(onboarding)/ballot/page.tsx
@@ -1,19 +1,24 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { PageTransition } from "@/components/layout/PageTransition";
 import { AppShell } from "@/components/layout/AppShell";
 import { useAuth } from "@/lib/store/auth";
 import { useUser } from "@/lib/store/user";
+import { Countdown } from "@/components/stage/Countdown";
+import { BingoGame } from "@/components/bingo/BingoGame";
+import { cn } from "@/lib/utils";
+
+type StageTab = "ballot" | "bingo";
 
 export default function BallotPage() {
   const router = useRouter();
   const { user } = useAuth();
   const { profile } = useUser();
+  const [tab, setTab] = useState<StageTab>("bingo");
 
-  // Redirect if not authenticated or profile incomplete
   useEffect(() => {
     if (!user) {
       router.push("/login");
@@ -28,8 +33,7 @@ export default function BallotPage() {
   return (
     <AppShell variant="dark" showLogo={true} showAvatar={false}>
       <PageTransition className="max-w-md mx-auto w-full">
-        <div className="space-y-8">
-          {/* Back to join */}
+        <div className="space-y-6">
           <p className="text-sm">
             <Link
               href="/party?stay=1"
@@ -39,15 +43,56 @@ export default function BallotPage() {
             </Link>
           </p>
 
-          {/* Header */}
-          <div className="text-center space-y-2">
-            <h1 className="text-3xl font-display font-bold">
-              Create your ballot
-            </h1>
-            <p className="text-muted-foreground">
-              Your predictions will go here.
-            </p>
+          <Countdown />
+
+          <div className="flex rounded-lg border border-border bg-muted/30 p-1">
+            <button
+              type="button"
+              onClick={() => setTab("ballot")}
+              className={cn(
+                "flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                tab === "ballot"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              My Ballots
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab("bingo")}
+              className={cn(
+                "flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                tab === "bingo"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              Red carpet bingo
+            </button>
           </div>
+
+          {tab === "ballot" && (
+            <div className="space-y-4">
+              <div className="text-center space-y-2">
+                <h2 className="text-xl font-display font-bold">
+                  Create your ballot
+                </h2>
+                <p className="text-muted-foreground text-sm">
+                  Your predictions will go here.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {tab === "bingo" && (
+            <div>
+              <h2 className="text-xl font-display font-bold text-center mb-4">
+                Red carpet bingo
+              </h2>
+              <BingoGame />
+            </div>
+          )}
         </div>
       </PageTransition>
     </AppShell>

--- a/src/components/bingo/BingoCard.tsx
+++ b/src/components/bingo/BingoCard.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+import {
+  GRID_ROWS,
+  GRID_COLS,
+  FREE_ROW,
+  FREE_COL,
+  BINGO_FREE_LABEL,
+  type BingoGrid,
+  type BingoClues,
+} from "@/lib/bingo";
+import { cn } from "@/lib/utils";
+import { BingoTokenPlaceholder } from "./BingoToken";
+
+export type MarkedGrid = boolean[][];
+
+const BINGO_LETTERS = ["B", "I", "N", "G", "O"];
+
+function cellId(row: number, col: number): string {
+  return `cell-${row}-${col}`;
+}
+
+const DOUBLE_TAP_MS = 400;
+const SINGLE_TAP_DELAY_MS = 300;
+
+interface BingoCellProps {
+  row: number;
+  col: number;
+  value: number; // 0 = FREE, 1-24 = number
+  clue: string | null;
+  marked: boolean;
+  onExpandClue: (phrase: string) => void;
+  onMarkCell?: (row: number, col: number) => void;
+}
+
+function BingoCell({
+  row,
+  col,
+  value,
+  clue,
+  marked,
+  onExpandClue,
+  onMarkCell,
+}: BingoCellProps) {
+  const id = cellId(row, col);
+  const isFree = value === 0;
+
+  const lastTapTime = useRef<number>(0);
+  const singleTapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const triggerMarkOrUnmark = useCallback(() => {
+    if (singleTapTimer.current) {
+      clearTimeout(singleTapTimer.current);
+      singleTapTimer.current = null;
+    }
+    if (onMarkCell) onMarkCell(row, col);
+  }, [onMarkCell, row, col]);
+
+  const triggerClue = useCallback(() => {
+    if (!isFree && clue) onExpandClue(clue);
+  }, [isFree, clue, onExpandClue]);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    e.stopPropagation();
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    e.stopPropagation();
+    const now = Date.now();
+    if (now - lastTapTime.current < DOUBLE_TAP_MS) {
+      lastTapTime.current = 0;
+      triggerMarkOrUnmark();
+      return;
+    }
+    lastTapTime.current = now;
+    if (singleTapTimer.current) clearTimeout(singleTapTimer.current);
+    singleTapTimer.current = setTimeout(() => {
+      singleTapTimer.current = null;
+      triggerClue();
+    }, SINGLE_TAP_DELAY_MS);
+  };
+
+  const handlePointerCancel = (e: React.PointerEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      data-cell-id={id}
+      className={cn(
+        "relative flex flex-col items-center justify-center min-h-[2.75rem] sm:min-h-[4rem] md:min-h-[5rem] p-0.5 sm:p-1.5 rounded-md sm:rounded-lg border border-border sm:border-2 bg-card text-card-foreground transition-colors",
+        isFree && "bg-muted/50",
+        marked && "bg-primary/10 border-primary/50"
+      )}
+    >
+      <button
+        type="button"
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onPointerLeave={handlePointerCancel}
+        className={cn(
+          "w-full h-full min-h-0 flex flex-col items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 sm:ring-offset-2 cursor-pointer",
+          "hover:bg-muted/50"
+        )}
+        title={clue ?? undefined}
+      >
+        <span
+          className={cn(
+            "w-full min-w-0 overflow-hidden text-center p-2 justify-center flex-1 flex items-center",
+            isFree
+              ? "font-display font-bold text-xs sm:text-base text-center"
+              : "text-xs leading-tight text-center sm:line-clamp-3 px-0.5"
+          )}
+        >
+          {isFree ? BINGO_FREE_LABEL : (clue ?? String(value))}
+        </span>
+      </button>
+      {marked && (
+        <span className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <BingoTokenPlaceholder />
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface BingoCardProps {
+  grid: BingoGrid;
+  clues: BingoClues;
+  marked: MarkedGrid;
+  onExpandPhrase: (phrase: string) => void;
+  onMarkCell?: (row: number, col: number) => void;
+}
+
+export function BingoCard({
+  grid,
+  clues,
+  marked,
+  onExpandPhrase,
+  onMarkCell,
+}: BingoCardProps) {
+  return (
+    <div className="w-full max-w-md mx-auto min-w-0 overflow-hidden space-y-1 sm:space-y-2 px-0">
+      {/* B I N G O header */}
+      <div
+        className="grid gap-0.5 sm:gap-1.5"
+        style={{ gridTemplateColumns: `repeat(${GRID_COLS}, minmax(0, 1fr))` }}
+      >
+        {BINGO_LETTERS.map((letter) => (
+          <div
+            key={letter}
+            className="flex items-center justify-center rounded-md sm:rounded-lg border border-border sm:border-2 bg-muted/50 py-1 sm:py-2 font-display font-bold text-sm== sm:text-lg"
+          >
+            {letter}
+          </div>
+        ))}
+      </div>
+
+      {/* 5x5 grid */}
+      <div
+        className="grid gap-0.5 sm:gap-1.5"
+        style={{
+          gridTemplateColumns: `repeat(${GRID_COLS}, minmax(0, 1fr))`,
+          gridTemplateRows: `repeat(${GRID_ROWS}, minmax(0, 1fr))`,
+        }}
+      >
+        {grid.map((row, r) =>
+          row.map((value, c) => (
+            <BingoCell
+              key={cellId(r, c)}
+              row={r}
+              col={c}
+              value={value}
+              clue={value > 0 ? clues[value - 1] ?? null : null}
+              marked={marked[r]?.[c] ?? false}
+              onExpandClue={onExpandPhrase}
+              onMarkCell={onMarkCell}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/bingo/BingoGame.tsx
+++ b/src/components/bingo/BingoGame.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { BingoCard } from "./BingoCard";
+import { generateCard, checkWin, GRID_ROWS, GRID_COLS } from "@/lib/bingo";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const POINTS_PER_BINGO = 1;
+
+function createEmptyMarked(): boolean[][] {
+  return Array(GRID_ROWS)
+    .fill(null)
+    .map(() => Array(GRID_COLS).fill(false));
+}
+
+export function BingoGame() {
+  const [card, setCard] = useState(() => generateCard());
+  const [marked, setMarked] = useState<boolean[][]>(() => createEmptyMarked());
+  const [points, setPoints] = useState(0);
+  const [hasWon, setHasWon] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
+  const [expandedPhrase, setExpandedPhrase] = useState<string | null>(null);
+
+  const handlePlayAgain = useCallback(() => {
+    setCard(generateCard());
+    setMarked(createEmptyMarked());
+    setHasWon(false);
+    setShowCelebration(false);
+  }, []);
+
+  const handleMarkCell = useCallback(
+    (row: number, col: number) => {
+      if (hasWon) return;
+      const currentlyMarked = marked[row]?.[col];
+      setMarked((prev) => {
+        const next = prev.map((r, rIdx) =>
+          r.map((c, cIdx) =>
+            rIdx === row && cIdx === col ? !currentlyMarked : c
+          )
+        );
+        if (!currentlyMarked && checkWin(next)) {
+          setHasWon(true);
+          setShowCelebration(true);
+          setPoints((p) => p + POINTS_PER_BINGO);
+        }
+        return next;
+      });
+    },
+    [marked, hasWon]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <p className="text-sm font-medium text-muted-foreground">
+          Wins: <span className="text-foreground tabular-nums">{points}</span>
+        </p>
+        {hasWon && (
+          <Button onClick={handlePlayAgain} size="sm">
+            Play again
+          </Button>
+        )}
+      </div>
+
+      {showCelebration && (
+        <div
+          className="rounded-lg border-2 border-primary bg-primary/10 p-4 text-center animate-in fade-in"
+          role="alert"
+        >
+          <p className="font-display font-bold text-primary text-lg">
+            Bingo!
+          </p>
+          <p className="text-sm text-muted-foreground">
+            +{POINTS_PER_BINGO} point. Get a new card and keep playing.
+          </p>
+        </div>
+      )}
+
+      <Dialog open={!!expandedPhrase} onOpenChange={(open) => !open && setExpandedPhrase(null)}>
+        <DialogContent showCloseButton={true}>
+          <DialogHeader>
+            <DialogTitle className="text-lg sr-only">Phrase</DialogTitle>
+          </DialogHeader>
+          <p className="text-2xl font-medium text-center leading-relaxed p-16">
+            {expandedPhrase}
+          </p>
+        </DialogContent>
+      </Dialog>
+
+      <BingoCard
+        grid={card.grid}
+        clues={card.clues}
+        marked={marked}
+        onExpandPhrase={setExpandedPhrase}
+        onMarkCell={handleMarkCell}
+      />
+
+      <p className="text-center text-xs text-muted-foreground pt-2">
+        Tap a square to read the clue.
+        Double-tap to mark or remove a marker.
+      </p>
+    </div>
+  );
+}

--- a/src/components/bingo/BingoToken.tsx
+++ b/src/components/bingo/BingoToken.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/core";
+import type { UniqueIdentifier } from "@dnd-kit/core";
+import { cn } from "@/lib/utils";
+
+interface BingoTokenProps {
+  id: UniqueIdentifier;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Draggable circle with see-through center (ring style) for bingo.
+ */
+export function BingoToken({ id, disabled, className }: BingoTokenProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id,
+    disabled,
+  });
+
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      {...listeners}
+      {...attributes}
+      disabled={disabled}
+      aria-label="Bingo token"
+      className={cn(
+        "touch-none rounded-full border-2 border-primary bg-transparent cursor-grab active:cursor-grabbing",
+        "size-8 sm:size-10 shrink-0",
+        "transition-opacity",
+        isDragging && "opacity-50 z-10",
+        disabled && "opacity-40 cursor-not-allowed",
+        className
+      )}
+      style={{
+        // Ring: see-through center (transparent fill already via bg-transparent)
+        boxShadow: "inset 0 0 0 2px transparent",
+      }}
+    />
+  );
+}
+
+/**
+ * Static token visual for when a cell is marked (same ring style).
+ */
+export function BingoTokenPlaceholder({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "rounded-full border-2 border-primary bg-primary/10 shrink-0 inline-block size-6 sm:size-8 md:size-10",
+        className
+      )}
+    />
+  );
+}

--- a/src/components/stage/Countdown.tsx
+++ b/src/components/stage/Countdown.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const DEFAULT_EVENT_ISO = "2026-03-02T01:00:00.000Z"; // Oscars 2026 example
+
+function getEventDate(): Date | null {
+  if (typeof window === "undefined") return null;
+  const iso = process.env.NEXT_PUBLIC_EVENT_START_ISO ?? DEFAULT_EVENT_ISO;
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatPart(n: number, label: string): string {
+  return `${n} ${label}${n !== 1 ? "s" : ""}`;
+}
+
+export function Countdown() {
+  const eventDate = getEventDate();
+  const [now, setNow] = useState(() => (typeof window !== "undefined" ? Date.now() : 0));
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  if (!mounted || !eventDate) {
+    return (
+      <div className="text-center text-muted-foreground text-sm">
+        Event time not set
+      </div>
+    );
+  }
+
+  const diff = Math.max(0, eventDate.getTime() - now);
+  const hasStarted = diff === 0;
+
+  if (hasStarted) {
+    return (
+      <div className="text-center">
+        <p className="text-xl font-display font-bold text-primary">Show time!</p>
+        <p className="text-muted-foreground text-sm">The red carpet is on.</p>
+      </div>
+    );
+  }
+
+  const seconds = Math.floor((diff / 1000) % 60);
+  const minutes = Math.floor((diff / 60000) % 60);
+  const hours = Math.floor((diff / 3600000) % 24);
+  const days = Math.floor(diff / 86400000);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(formatPart(days, "day"));
+  if (hours > 0) parts.push(formatPart(hours, "hr"));
+  parts.push(formatPart(minutes, "min"));
+  parts.push(formatPart(seconds, "sec"));
+
+  return (
+    <div className="text-center space-y-1">
+      <p className="text-muted-foreground text-sm">Time until the show</p>
+      <p className="text-xl font-display font-bold tabular-nums">
+        {parts.join(" ")}
+      </p>
+    </div>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -70,7 +70,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-6"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/src/data/bingo-phrases.ts
+++ b/src/data/bingo-phrases.ts
@@ -1,0 +1,80 @@
+/**
+ * Red carpet bingo phrases. One flat list for card generation (24 random per card + FREE center).
+ * Categories kept for reference only.
+ */
+
+export const BINGO_FREE_LABEL = "FREE";
+
+export const BINGO_PHRASES: string[] = [
+  // Red Carpet Interview Classics
+  "So who are you wearing?",
+  "How does it feel to be here tonight?",
+  "Actor calls the night \"surreal\"",
+  "\"It was such an honor\" (said twice)",
+  "Interview ends abruptly mid-sentence",
+  "Someone forgets the interviewer's name",
+  "Clearly rehearsed answer delivered too smoothly",
+  "\"I'm just so grateful to be nominated\"",
+  "Question is answered without answering the question",
+  "Shout-out to \"the fans\" unprompted",
+  // Fashion & Styling Shenanigans
+  "Outfit described as \"timeless\"",
+  "Outfit described as \"bold\"",
+  "Someone needs help walking",
+  "Train gets stepped on",
+  "Last-minute outfit adjustment on camera",
+  "Wind causes minor fashion panic",
+  "Dress pockets are revealed (huge applause energy)",
+  "\"This look took over ___ hours to make\"",
+  "Jewelry gets its own close-up",
+  "Shoes nearly cause a wipeout",
+  // Awkward & Unhinged Moments
+  "Awkward pause after a question",
+  "Interviewer interrupts the answer",
+  "Celebrity waves at someone off-camera",
+  "Publicist gently pulls someone away",
+  "Over-enthusiastic compliment gets weird",
+  "Someone pretends not to hear a question",
+  "Accidental name mispronunciation",
+  "Celebrity talks over the interviewer",
+  "Mic gets adjusted mid-sentence",
+  "Someone clearly arrives late and is rushing",
+  // Celebrity Behavior Bingo
+  "Celebrity greets another celebrity mid-interview",
+  "Someone mentions their mom",
+  "Someone mentions their kids",
+  "Couple kisses for the camera",
+  "Someone says \"I didn't expect this\"",
+  "Celebrity thanks their stylist by name",
+  "Someone jokes about being nervous",
+  "Someone admits they haven't eaten",
+  "Sunglasses worn at night",
+  "Celebrity takes control of the interview",
+  // Camera & Production Moments
+  "Photographer yelling \"LOOK THIS WAY!\"",
+  "Flash storm causes blinking panic",
+  "Camera zooms way too close",
+  "Shot cuts away at the wrong moment",
+  "Interviewer reacts dramatically to an outfit",
+  "Split-screen chaos",
+  "Background celebrity steals focus",
+  "Audio cuts out briefly",
+  "Crowd noise overwhelms conversation",
+  "Host says \"We'll let you go…\"",
+  // Red Carpet Energy Vibes
+  "\"This night is all about celebrating film\"",
+  "\"It's an incredible year for cinema\"",
+  "Someone references \"the craft\"",
+  "Someone says \"community\"",
+  "Someone says \"storytelling\"",
+  "Someone calls the carpet \"electric\"",
+  "Host reminds us it's almost showtime",
+  "\"This is why we do what we do\"",
+  "\"Just happy to be here\"",
+  "Deep answer to a very light question",
+  // Free Space ideas (merged into pool for 24 cells)
+  "Awkward silence",
+  "Train malfunction",
+  "Interview ends too soon",
+  "Someone says \"surreal\"",
+];

--- a/src/lib/bingo.ts
+++ b/src/lib/bingo.ts
@@ -1,0 +1,93 @@
+import { BINGO_FREE_LABEL, BINGO_PHRASES } from "@/data/bingo-phrases";
+
+const ROWS = 5;
+const COLS = 5;
+const FREE_ROW = 2;
+const FREE_COL = 2;
+const NUMBERS_COUNT = 24; // 1–24, center is FREE (0)
+
+/**
+ * Card cell value: 0 = FREE space, 1–24 = number that corresponds to a clue.
+ */
+export type BingoGrid = number[][];
+
+/**
+ * Clues in order: clues[n-1] is the phrase for number n.
+ */
+export type BingoClues = string[];
+
+export interface BingoCardData {
+  grid: BingoGrid;
+  clues: BingoClues;
+}
+
+/**
+ * Shuffle array (Fisher–Yates) and return a copy.
+ */
+function shuffle<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/**
+ * Generate a 5x5 bingo card. Top row will be under B-I-N-G-O headers.
+ * Center [2][2] is FREE (0). Other 24 cells get numbers 1–24; each number maps to one clue.
+ */
+export function generateCard(): BingoCardData {
+  const shuffled = shuffle(BINGO_PHRASES).slice(0, NUMBERS_COUNT);
+  const clues: BingoClues = [...shuffled];
+
+  // Build list of (row, col) for non-FREE cells, then shuffle to randomize number placement
+  const positions: { r: number; c: number }[] = [];
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      if (r !== FREE_ROW || c !== FREE_COL) positions.push({ r, c });
+    }
+  }
+  const shuffledPositions = shuffle(positions);
+
+  const grid: BingoGrid = [
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+  ];
+  grid[FREE_ROW][FREE_COL] = 0; // FREE
+
+  shuffledPositions.forEach(({ r, c }, i) => {
+    grid[r][c] = i + 1; // numbers 1–24
+  });
+
+  return { grid, clues };
+}
+
+/**
+ * Check for bingo: full row (5), full column (5), or either 5-cell diagonal.
+ * FREE (center) is always considered marked.
+ */
+export function checkWin(marked: boolean[][]): boolean {
+  const isMarked = (r: number, c: number) => {
+    if (r === FREE_ROW && c === FREE_COL) return true;
+    return marked[r]?.[c] === true;
+  };
+
+  for (let r = 0; r < ROWS; r++) {
+    if (Array.from({ length: COLS }, (_, c) => c).every((c) => isMarked(r, c)))
+      return true;
+  }
+  for (let c = 0; c < COLS; c++) {
+    if (Array.from({ length: ROWS }, (_, r) => r).every((r) => isMarked(r, c)))
+      return true;
+  }
+  if ([0, 1, 2, 3, 4].every((i) => isMarked(i, i))) return true;
+  if ([0, 1, 2, 3, 4].every((i) => isMarked(i, COLS - 1 - i))) return true;
+
+  return false;
+}
+
+export { ROWS as GRID_ROWS, COLS as GRID_COLS, FREE_ROW, FREE_COL, BINGO_FREE_LABEL };


### PR DESCRIPTION
## Red Carpet Bingo!

During the show, users get a 5×5 bingo card. Each square (except the center FREE space) shows a short clue—e.g. “Outfit described as ‘bold’” or “Someone forgets the interviewer’s name.” The center square is labeled FREE.

**How to play:** When something matches a clue, **double-tap** that square to place a marker. Double-tap again to remove it. **Single-tap** a square to open the full clue in a popup. The FREE space can be marked too.

**Winning:** Get five in a row (horizontal, vertical, or diagonal). The FREE space always counts as marked for those lines. When you get a bingo, you earn a point and can get a new card and keep playing.

**Mobile-friendly:** The card fits small screens; clues are shortened in the grid and you can tap to read the full text.

<img width="489" height="746" alt="Screenshot 2026-02-05 at 9 58 05 PM" src="https://github.com/user-attachments/assets/1ac76dd5-0832-46e3-a97e-efeefe50edea" />
