### PR TITLE
removes passthru links in sign up flow

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -58,18 +58,7 @@ export default function LoginPage() {
             <EmailForm onSubmit={handleSubmit} isLoading={isLoading} />
 
             {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
-
-            {/* Dev only: skip email and go straight to simulate flow */}
-            <button
-              type="button"
-              onClick={() => {
-                signInWithEmail("prototype@example.com");
-                router.push("/verify");
-              }}
-              className="mt-4 w-full text-sm text-muted-foreground hover:text-foreground transition-colors underline"
-            >
-              Pretend I have one
-            </button>
+            
           </Card>
         </main>
       </PageTransition>

--- a/src/app/(auth)/verify/page.tsx
+++ b/src/app/(auth)/verify/page.tsx
@@ -79,10 +79,6 @@ export default function VerifyPage() {
                 Open email app
               </Button>
 
-              {/* Prototype: Simulate magic link click */}
-              <Button className="w-full h-12" onClick={handleSimulateMagicLink}>
-                Simulate magic link click
-              </Button>
             </div>
 
             <button


### PR DESCRIPTION
Fixes #15
in sign up flow:
- removes the "pretend i have one" magic link pass thru
- removes the fake simulate link button