### PR TITLE
Part 1 of 2: Initial Leaderboard page

### DIFF
--- a/src/app/(onboarding)/live/leaderboard/page.tsx
+++ b/src/app/(onboarding)/live/leaderboard/page.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { ArrowRight, ChevronLeft } from "lucide-react";
 import { AppShell } from "@/components/layout/AppShell";
+import { PageTransition } from "@/components/layout/PageTransition";
+import { Button } from "@/components/ui/button";
 import {
   getDeclaredWinners,
   getCorrectGuessCount,
@@ -76,30 +79,40 @@ export default function LeaderboardPage() {
 
   if (!mounted) {
     return (
-      <AppShell variant="dark" showLogo={true} showAvatar={false}>
-        <div className="max-w-md mx-auto w-full flex flex-col min-h-0">
-          <div className="flex-1" />
-        </div>
+      <AppShell variant="light" showLogo={true} showAvatar={false}>
+        <PageTransition className="max-w-md mx-auto w-full">
+          <div className="flex flex-col min-h-0 flex-1">
+            <div className="flex-1" />
+          </div>
+        </PageTransition>
       </AppShell>
     );
   }
 
   return (
-    <AppShell variant="dark" showLogo={true} showAvatar={false}>
-      <div className="max-w-md mx-auto w-full flex flex-col min-h-0">
-        <header className="flex items-center justify-between gap-3 py-3 border-b border-border">
-          <Link
-            href="/live"
-            className="text-sm font-medium text-muted-foreground hover:text-foreground"
-          >
-            ← Back to live
-          </Link>
-        </header>
+    <AppShell variant="light" showLogo={true} showAvatar={false}>
+      <PageTransition className="max-w-md mx-auto w-full flex flex-col min-h-0">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" asChild>
+            <Link href="/ballot" aria-label="Back to ballots">
+              <ChevronLeft className="size-5" />
+            </Link>
+          </Button>
+          <h1 className="text-2xl font-display font-bold flex-1 text-center pr-9">
+            Leaderboard
+          </h1>
+          <Button variant="outline" asChild>
+            <Link href="/live" aria-label="Back to live" className="flex items-center gap-1.5">
+              <ArrowRight className="size-4" />
+              Back to show
+            </Link>
+          </Button>
+        </div>
         <div className="flex-1 overflow-y-auto flex flex-col py-6">
           <LeaderboardHero leaders={leaders} />
           <LeaderboardList rankedUsers={nonLeaderRanked} />
         </div>
-      </div>
+      </PageTransition>
     </AppShell>
   );
 }

--- a/src/app/(onboarding)/live/page.tsx
+++ b/src/app/(onboarding)/live/page.tsx
@@ -109,6 +109,7 @@ function LivePageContent({
   declaredWinnerId,
   selectedBallotNomineeId,
   onSelectWinner,
+  leaderNames,
 }: {
   /** Current user's ballots only (for bottom nav). */
   myBallots: BallotSummary[];
@@ -126,6 +127,8 @@ function LivePageContent({
   declaredWinnerId: string | undefined;
   selectedBallotNomineeId: string | null;
   onSelectWinner: (nomineeId: string) => void;
+  /** Names of user(s) currently in the lead (best ballot score). */
+  leaderNames: string[];
 }) {
   const [overId, setOverId] = useState<string | number | null>(null);
 
@@ -143,6 +146,13 @@ function LivePageContent({
   const isOverNominee =
     overIdStr != null && overIdStr.startsWith("nominee-");
 
+  const leaderLabel =
+    leaderNames.length === 0
+      ? null
+      : leaderNames.length === 1
+        ? `Current leader: ${leaderNames[0]}`
+        : `Current leaders: ${leaderNames.join(" & ")}`;
+
   return (
     <div className="flex-1 overflow-y-auto flex flex-col">
       <div className="shrink-0 border-b-0">
@@ -151,6 +161,11 @@ function LivePageContent({
           currentCategoryIndex={currentCategoryIndex}
           onSelectCategoryIndex={setCurrentCategoryIndex}
         />
+        {leaderLabel && (
+          <p className="text-center text-sm text-muted-foreground pt-1 px-2">
+            {leaderLabel}
+          </p>
+        )}
         <h2 className="text-center text-3xl font-display font-bold py-3">
           {currentCategory?.name ?? "—"}
         </h2>
@@ -364,6 +379,7 @@ export default function LivePage() {
             declaredWinnerId={declaredWinnerId}
             selectedBallotNomineeId={selectedBallotNomineeId}
             onSelectWinner={handleSelectWinner}
+            leaderNames={MOCK_USERS.filter((u) => leaderUserIds.includes(u.id)).map((u) => u.name)}
           />
         </DndContext>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,3 +216,18 @@
     transform: translateX(200%) skewX(-12deg);
   }
 }
+
+/* Slow shine: long pause then sweep, for periodic trophy highlight (e.g. every 5s) */
+@keyframes shine-slow {
+  0%,
+  80% {
+    transform: translateX(-100%) skewX(-12deg);
+  }
+  100% {
+    transform: translateX(200%) skewX(-12deg);
+  }
+}
+
+.animate-shine-slow {
+  animation: shine-slow 5s ease-in-out infinite;
+}

--- a/src/components/live/LeaderboardHero.tsx
+++ b/src/components/live/LeaderboardHero.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Star } from "lucide-react";
+import Image from "next/image";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+} from "@/components/ui/card";
 import type { LeaderboardUserRow } from "@/lib/live/types";
 
 export interface LeaderboardHeroProps {
@@ -8,31 +13,41 @@ export interface LeaderboardHeroProps {
   leaders: LeaderboardUserRow[];
 }
 
-/** Hero: AwardStatue image, leader user name(s), "Guessed X correct winners". Dumb UI. */
+/** Hero: Current Leader card with award image, single leader name, "X picks". */
 export function LeaderboardHero({ leaders }: LeaderboardHeroProps) {
-  if (leaders.length === 0) {
-    return (
-      <section className="text-center py-8" aria-label="Leaderboard hero">
-        <div className="w-16 h-16 mx-auto rounded-full bg-amber-500/20 flex items-center justify-center text-amber-500 border border-amber-500/40 mb-4">
-          <Star className="w-8 h-8" strokeWidth={1.5} fill="currentColor" />
-        </div>
-        <p className="text-muted-foreground">No one on the board yet</p>
-      </section>
-    );
-  }
-
-  const count = leaders[0]!.correctCount;
-  const names = leaders.map((l) => l.user.name).join(" | ");
+  const leader = leaders[0];
 
   return (
-    <section className="text-center py-8" aria-label="Leaderboard hero">
-      <div className="w-16 h-16 mx-auto rounded-full bg-amber-500/20 flex items-center justify-center text-amber-500 border border-amber-500/40 mb-4">
-        <Star className="w-8 h-8" strokeWidth={1.5} fill="currentColor" />
-      </div>
-      <h2 className="text-xl font-semibold text-foreground">{names}</h2>
-      <p className="text-muted-foreground mt-1">
-        Guessed {count} correct winner{count !== 1 ? "s" : ""}
-      </p>
-    </section>
+    <Card variant="dark" className="overflow-hidden shadow-md w-3/4 mx-auto" aria-labelledby="leaderboard-current-leader">
+      <CardHeader>
+        <h2 id="leaderboard-current-leader" className="text-lg font-display font-bold leading-none">
+          Current Leader
+        </h2>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-1 pb-6">
+        <div className="w-[56px] h-[142px] flex items-center justify-center">
+          <Image
+            src="/images/award.svg"
+            alt=""
+            width={56}
+            height={142}
+          />
+        </div>
+        {leader ? (
+          <>
+            <p className="font-display font-bold text-lg text-white">
+              {leader.user.name}
+            </p>
+            <p className="font-display text-base text-[#FEF6DA]">
+              {leader.correctCount} pick{leader.correctCount !== 1 ? "s" : ""}
+            </p>
+          </>
+        ) : (
+          <p className="font-display text-base text-[#FEF6DA]">
+            No one on the board yet
+          </p>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/live/LeaderboardList.tsx
+++ b/src/components/live/LeaderboardList.tsx
@@ -11,8 +11,8 @@ export interface LeaderboardListProps {
 export function LeaderboardList({ rankedUsers }: LeaderboardListProps) {
   if (rankedUsers.length === 0) {
     return (
-      <section className="py-4" aria-label="Leaderboard list">
-        <p className="text-muted-foreground text-sm text-center">
+      <section className="px-4 pt-6 pb-4" aria-label="Leaderboard list">
+        <p className="font-display text-base text-muted-foreground text-center">
           No other players to show
         </p>
       </section>
@@ -20,16 +20,16 @@ export function LeaderboardList({ rankedUsers }: LeaderboardListProps) {
   }
 
   return (
-    <section className="py-4" aria-label="Leaderboard list">
-      <ul className="space-y-2">
+    <section className="pt-6 pb-4 w-3/4 mx-auto" aria-label="Leaderboard list">
+      <ul className="space-y-3">
         {rankedUsers.map(({ user, correctCount }) => (
           <li
             key={user.id}
-            className="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3"
+            className="flex items-center justify-between"
           >
-            <span className="font-medium">{user.name}</span>
-            <span className="text-muted-foreground text-sm">
-              {correctCount} correct
+            <span className="font-display font-medium text-base text-foreground">{user.name}</span>
+            <span className="font-display text-base text-muted-foreground">
+              {correctCount} pick{correctCount !== 1 ? "s" : ""}
             </span>
           </li>
         ))}


### PR DESCRIPTION
- adds a leaderboard showcasing who is in the lead -connects back to "live" mode screen
- shows current leader on live mode at top in text

i'll do some polish on this in a different commit, but this is the stubbed out pieces that are ready to hook up